### PR TITLE
Optimize linux.mk:

### DIFF
--- a/template/linux.mk
+++ b/template/linux.mk
@@ -8,7 +8,7 @@ MKDIR = mkdir
 DIR_BUILD = .build
 prefix = /usr/local
 
-PPFLAGS = -MT $@ -MMD -MP -MF $(DIR_BUILD)/$*.d
+PPFLAGS = -MT $@ -MMD -MP -MF $(patsubst %.o, %.d, $@)
 
 CFLAGS_LOCAL = -Wall -g -std=c99 -coverage
 CFLAGS_LOCAL += $(CFLAGS)


### PR DESCRIPTION
  1.  Using automatic variable instead of $(DIR_BUILD) of dependency file output.